### PR TITLE
Relax RSA signature check

### DIFF
--- a/ssh/server.go
+++ b/ssh/server.go
@@ -418,7 +418,7 @@ func algoCompatible(algo string, publicKey PublicKey, sig *Signature) bool {
 		return true
 	}
 
-	if publicKey.Type() == CertAlgoRSAv01 && isRSAType(algo) && isRSAType(sig.Format) {
+	if publicKey.Type() == CertAlgoRSAv01 && isRSACertType(algo) && isRSAType(sig.Format) {
 		return true
 	}
 


### PR DESCRIPTION
Based on https://github.com/golang/crypto/pull/221

This PR also relaxes the check for SSH certificates. Older OpenSSH clients versions (7.4 included in CentOS 7 for example) that don't understand `rsa-sha2-256-cert-v01@openssh.com` or `rsa-sha2-512-cert-v01@openssh.com` send SSH certificates signed SHA2 and the public key type set to `ssh-rsa-cert-v01@openssh.com`. Currently, this combination is rejected by `go/crypto`. OpenSSH implemented their own workaround for the problem https://github.com/openssh/openssh-portable/blob/25c8a2bbcc10c493d27faea57c42a6bf13fa51f2/ssh-rsa.c#L505-L518
https://github.com/openssh/openssh-portable/commit/4ba0d54794814ec0de1ec87987d0c3b89379b436
